### PR TITLE
Update Docia to 0.0.15

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -13,7 +13,7 @@
       "devDependencies": {
         "@types/bun": "^1.3.8",
         "@types/node": "^25.1.0",
-        "docia": "^0.0.10",
+        "docia": "^0.0.15",
         "oxfmt": "^0.27.0",
         "oxlint": "^1.42.0",
         "publint": "^0.3.17",
@@ -108,7 +108,7 @@
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
-    "docia": ["docia@0.0.10", "", { "dependencies": { "minisearch": "^7.2.0", "picocolors": "^1.1.1", "react": "^19.2.4", "react-dom": "^19.2.4", "shiki": "^3.22.0" }, "peerDependencies": { "typescript": "^5" }, "bin": { "docia": "src/cli.ts" } }, "sha512-6gBIkMJrEcNIQ0sQ95BogHswvz5T4ugiHDG/oe1Jvmi0D94oW2fGg/8BxTt5HMLnZqAcnQiFKszAvMqweWw1yQ=="],
+    "docia": ["docia@0.0.15", "", { "dependencies": { "minisearch": "^7.2.0", "picocolors": "^1.1.1", "react": "^19.2.4", "react-dom": "^19.2.4", "shiki": "^3.22.0" }, "peerDependencies": { "typescript": "^5" }, "bin": { "docia": "src/cli.ts" } }, "sha512-s//XvUQbtZflB0uSaPTb9xFIe4U1Ww+hXQ5BaLL5a7ZmLZ/L+yeCxNnVQztkHxCBC6WDPrXzkNqzrL5L2LK5XA=="],
 
     "fast-glob": ["fast-glob@3.3.3", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.8" } }, "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg=="],
 

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 	"devDependencies": {
 		"@types/bun": "^1.3.8",
 		"@types/node": "^25.1.0",
-		"docia": "^0.0.10",
+		"docia": "^0.0.15",
 		"oxfmt": "^0.27.0",
 		"oxlint": "^1.42.0",
 		"publint": "^0.3.17"


### PR DESCRIPTION
## Summary

- update the Docia development dependency from 0.0.10 to 0.0.15
- refresh the Bun lockfile for the new release

## Impact

The documentation toolchain now uses the latest Docia release. Application APIs and CLI behavior are unchanged.

## Validation

- `bun run docs:build`
- `bun run format:check`