### PR TITLE
Add zero-config monorepo orchestration

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,9 @@ jobs:
             - name: Build
               run: bun run build
 
+            - name: Build documentation
+              run: bun run docs:build
+
             - name: Check formatting
               run: bun run format:check
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,13 @@ A **universal CLI tool** for orchestrating scripts across **monorepo workspaces*
 - 🏗️ **Smart build ordering** respecting package dependencies
 - 📺 **Real-time log streaming** with timestamps
 - 💾 **Smart build caching** - skip unchanged packages automatically
+- 📁 **Artifact restoration** inferred from package metadata (`files`, exports, entry points)
+- 🎯 **Affected package detection** from Git changes and downstream dependents
+- 🔗 **Relationship filters** for dependencies and dependents
+- 🧭 **Dry runs and dependency graph output** for CI planning
 - 🎯 **Zero configuration** - works with any workspace setup
 - 🌐 **Universal support** - works with Bun, pnpm, and npm workspaces
+- 🧶 **Yarn Berry support** with explicit modern Yarn detection
 
 ## 🛠️ Installation
 
@@ -85,6 +90,10 @@ Add to your `package.json` scripts and run with your package manager:
 - `-c, --concurrency <number>` - Maximum concurrent processes (default: 4)
 - `-f, --filter <pattern>` - Filter packages by glob pattern
 - `--sequential` - Run scripts sequentially (default is parallel)
+- `--topological` - Run dependencies before dependents
+- `--affected` / `--since <ref>` - Run only packages affected by Git changes
+- `--dry-run` - Print the plan without starting scripts
+- `--fail-fast`, `--continue-on-error`, `--retry`, `--timeout` - Control failures
 
 **Examples:**
 
@@ -216,6 +225,29 @@ wsu cache clear
 ```
 
 ## 🔍 Package Filtering
+
+Filters are repeatable and support package names, paths, exclusions, dependencies, and dependents:
+
+```bash
+wsu run test --filter 'app...'          # app and its dependencies
+wsu run test --filter '...core'         # core and all dependents
+wsu run test --filter './apps/*'        # packages by directory
+wsu run test --filter '@scope/*' --filter '!@scope/docs'
+```
+
+## Changed packages, plans, and graphs
+
+```bash
+wsu run test --affected
+wsu build --since origin/main
+wsu build --dry-run
+wsu graph --format text
+wsu graph --format json
+wsu graph --format dot
+wsu --output json run test --affected   # newline-delimited JSON events
+```
+
+Build artifacts are inferred exclusively from package metadata. Packages without declared output paths still build normally but are not artifact-cached.
 
 Use glob patterns to target specific packages:
 

--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -15,6 +15,7 @@
     - [dev](./commands/dev.md)
     - [cache](./commands/cache.md)
     - [clean](./commands/clean.md)
+    - [graph](./commands/graph.md)
 
 # Usage Examples
 

--- a/docs/src/commands/graph.md
+++ b/docs/src/commands/graph.md
@@ -1,0 +1,19 @@
+# graph
+
+Inspect the selected workspace dependency graph without running scripts.
+
+```bash
+wsu graph [options]
+```
+
+Options:
+
+- `--filter <selector>` — repeatable package selector
+- `--affected` — packages changed relative to the detected merge base, plus dependents
+- `--since <ref>` — use an explicit Git comparison ref
+- `--format text|json|dot` — output format; defaults to `text`
+
+```bash
+wsu graph --filter 'app...' --format dot
+wsu graph --affected --format json
+```

--- a/docs/src/commands/overview.md
+++ b/docs/src/commands/overview.md
@@ -1,6 +1,6 @@
 # Commands Overview
 
-workspace-utils provides four main commands designed to handle different aspects of monorepo workflow management. Each command is optimized for specific use cases while sharing common functionality like package filtering and concurrency control.
+workspace-utils provides commands for task execution, dependency-aware builds, development, cleanup, cache management, and graph inspection. Commands share package selection, affected detection, dry-run, and failure controls where applicable.
 
 ## Command Summary
 
@@ -10,6 +10,20 @@ workspace-utils provides four main commands designed to handle different aspects
 | [`build`](./build.md) | Build packages respecting dependencies | **Dependency order** | Production builds, CI/CD       |
 | [`dev`](./dev.md)     | Start development servers              | **Parallel**         | Local development              |
 | [`clean`](./clean.md) | Remove node_modules directories        | **Sequential**       | Fresh installs, disk cleanup   |
+| `graph`               | Inspect workspace dependencies         | **Read-only**        | Planning and CI diagnostics    |
+
+## Advanced selection
+
+Use repeatable filters to compose package sets. A trailing ellipsis includes dependencies, a leading ellipsis includes dependents, `./` matches package directories, and `!` excludes matches.
+
+```bash
+wsu run test --filter 'app...'
+wsu run test --filter '...core' --filter '!docs'
+wsu build --affected
+wsu build --since origin/main
+```
+
+Add `--dry-run` to inspect a plan without executing or mutating the workspace. Add global `--output json` for newline-delimited execution events.
 
 ## Quick Reference
 

--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -20,11 +20,11 @@ All configuration is done through command-line options. Here are the most common
 
 Available for all commands:
 
-| Option                   | Description                     | Default      | Example               |
-| ------------------------ | ------------------------------- | ------------ | --------------------- |
-| `--filter <pattern>`     | Filter packages by glob pattern | All packages | `--filter "@scope/*"` |
-| `--concurrency <number>` | Max concurrent processes        | `4`          | `--concurrency 8`     |
-| `--help`                 | Show command help               | -            | `--help`              |
+| Option                   | Description                                    | Default      | Example             |
+| ------------------------ | ---------------------------------------------- | ------------ | ------------------- |
+| `--filter <pattern>`     | Repeatable relationship-aware package selector | All packages | `--filter "app..."` |
+| `--concurrency <number>` | Max concurrent processes                       | `4`          | `--concurrency 8`   |
+| `--help`                 | Show command help                              | -            | `--help`            |
 
 ### Command-Specific Options
 
@@ -210,7 +210,7 @@ workspace-utils run lint --concurrency 2
 
 ## Build Caching
 
-The `build` command includes intelligent caching to skip unchanged packages:
+The `build` command includes intelligent caching and restores declared build artifacts. Output paths are inferred from `files`, `main`, `module`, `types`, `typings`, `bin`, and `exports` in each package's `package.json`. No conventional output directory is guessed; packages without inferable outputs build normally without artifact caching.
 
 ### How Caching Works
 

--- a/index.ts
+++ b/index.ts
@@ -8,6 +8,8 @@ import { buildCommand } from "./src/commands/build.ts";
 import { devCommand } from "./src/commands/dev.ts";
 import { cleanCommand } from "./src/commands/clean.ts";
 import { cacheCommand } from "./src/commands/cache.ts";
+import { graphCommand } from "./src/commands/graph.ts";
+import { installJsonReporter } from "./src/core/reporter.ts";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -36,34 +38,52 @@ program
 	.description("CLI tool to orchestrate scripts across monorepo workspaces (Bun, pnpm, npm)")
 	.version(packageJson.version as string)
 	.option("--ascii", "Force ASCII output (no Unicode/emoji characters)", false);
+program.option("--output <format>", "Output format (human or json)", "human");
+
+const collect = (value: string, previous: string[]) => previous.concat([value]);
+const common = (command: Command) =>
+	command
+		.option("-f, --filter <pattern>", "Filter packages (repeatable)", collect, [])
+		.option("--affected", "Only affected packages", false)
+		.option("--since <ref>", "Git comparison ref (implies --affected)")
+		.option("--dry-run", "Show the execution plan without changing anything", false);
+const execution = (command: Command) =>
+	common(command)
+		.option("--fail-fast", "Stop after the first final failure", false)
+		.option("--continue-on-error", "Run downstream tasks after failures", false)
+		.option("--retry <count>", "Retry failed tasks", "0")
+		.option("--timeout <duration>", "Per-attempt timeout");
+const prepare = () => {
+	if (program.opts().output === "json") installJsonReporter();
+	else if (program.opts().output !== "human")
+		throw new Error(`Unknown output format: ${program.opts().output}`);
+	if (program.opts().ascii) process.env.WSU_ASCII = "1";
+};
 
 // Run command - execute a script across packages
-program
-	.command("run <script>")
-	.description("Run a script across multiple packages")
-	.option("-c, --concurrency <number>", "Maximum number of concurrent processes", "4")
-	.option("-f, --filter <pattern>", "Filter packages by pattern (e.g., @scope/*)")
-	.option("--sequential", "Run scripts sequentially (default is parallel)", false)
-	.action((script, options) => {
-		if (program.opts().ascii) {
-			process.env.WSU_ASCII = "1";
-		}
-		return runCommand(script, options);
-	});
+execution(
+	program
+		.command("run <script>")
+		.description("Run a script across multiple packages")
+		.option("-c, --concurrency <number>", "Maximum number of concurrent processes", "4")
+		.option("--sequential", "Run scripts sequentially (default is parallel)", false)
+		.option("--topological", "Run workspace dependencies first", false),
+).action((script, options) => {
+	prepare();
+	return runCommand(script, options);
+});
 
 // Build command - build packages in dependency order
-program
-	.command("build")
-	.description("Build packages in dependency order")
-	.option("-f, --filter <pattern>", "Filter packages by pattern")
-	.option("-c, --concurrency <number>", "Maximum number of concurrent builds", "4")
-	.option("--no-skip-unchanged", "Disable skipping unchanged packages (build all)")
-	.action((options) => {
-		if (program.opts().ascii) {
-			process.env.WSU_ASCII = "1";
-		}
-		return buildCommand(options);
-	});
+execution(
+	program
+		.command("build")
+		.description("Build packages in dependency order")
+		.option("-c, --concurrency <number>", "Maximum number of concurrent builds", "4")
+		.option("--no-skip-unchanged", "Disable skipping unchanged packages (build all)"),
+).action((options) => {
+	prepare();
+	return buildCommand(options);
+});
 
 // Dev command - run dev scripts in parallel with live logs
 program
@@ -72,34 +92,36 @@ program
 	.option("-f, --filter <pattern>", "Filter packages by pattern")
 	.option("-c, --concurrency <number>", "Maximum number of concurrent processes", "4")
 	.action((options) => {
-		if (program.opts().ascii) {
-			process.env.WSU_ASCII = "1";
-		}
+		prepare();
 		return devCommand(options);
 	});
 
 // Clean command - remove node_modules across packages
-program
-	.command("clean")
-	.description("Remove node_modules directories across all packages")
-	.option("-f, --filter <pattern>", "Filter packages by pattern")
-	.action((options) => {
-		if (program.opts().ascii) {
-			process.env.WSU_ASCII = "1";
-		}
-		return cleanCommand(options);
-	});
+common(
+	program.command("clean").description("Remove node_modules directories across all packages"),
+).action((options) => {
+	prepare();
+	return cleanCommand(options);
+});
 
 // Cache command - manage build cache
 program
 	.command("cache [command]")
 	.description("Manage build cache (clear, status)")
 	.action((command, options) => {
-		if (program.opts().ascii) {
-			process.env.WSU_ASCII = "1";
-		}
+		prepare();
 		return cacheCommand({ command, ...options });
 	});
+
+common(
+	program
+		.command("graph")
+		.description("Print the workspace dependency graph")
+		.option("--format <format>", "Graph format (text, json, dot)", "text"),
+).action((options) => {
+	prepare();
+	return graphCommand(options);
+});
 
 // Default to help if no command provided
 if (process.argv.length <= 2) {

--- a/src/commands/build.test.ts
+++ b/src/commands/build.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from "bun:test";
-import { mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
+import { mkdirSync, writeFileSync, rmSync, existsSync, readFileSync } from "fs";
 import { join } from "path";
 import { buildCommand } from "./build.ts";
 import { ProcessRunner } from "../core/process-runner.ts";
@@ -66,25 +66,17 @@ describe("buildCommand", () => {
 	});
 
 	it("includes dependencies when a filter is provided", async () => {
-		const receivedBatches: string[][] = [];
-		const runBatchesSpy = spyOn(ProcessRunner, "runBatches").mockImplementation(
-			async (batches) => {
-				for (const batch of batches) {
-					receivedBatches.push(
-						batch.filter((cmd) => Boolean(cmd)).map((cmd) => cmd.logOptions.prefix),
-					);
-				}
-
-				return batches
-					.flat()
-					.filter((cmd) => Boolean(cmd))
-					.map((cmd) => ({
-						success: true,
-						exitCode: 0,
-						packageName: cmd.logOptions.prefix,
-						command: [cmd.command, ...cmd.args].join(" "),
-						duration: 10,
-					}));
+		const receivedPackages: string[] = [];
+		const runCommandSpy = spyOn(ProcessRunner, "runCommand").mockImplementation(
+			async (command, args, _options, logOptions) => {
+				receivedPackages.push(logOptions.prefix);
+				return {
+					success: true,
+					exitCode: 0,
+					packageName: logOptions.prefix,
+					command: [command, ...args].join(" "),
+					duration: 10,
+				};
 			},
 		);
 
@@ -94,11 +86,31 @@ describe("buildCommand", () => {
 
 		try {
 			await buildCommand({ filter: "*app*" });
-			expect(receivedBatches).toEqual([["@test/lib"], ["@test/app"]]);
-			expect(runBatchesSpy).toHaveBeenCalled();
+			expect(receivedPackages).toEqual(["@test/lib", "@test/app"]);
+			expect(runCommandSpy).toHaveBeenCalled();
 		} finally {
-			runBatchesSpy.mockRestore();
+			runCommandSpy.mockRestore();
 			processExitSpy.mockRestore();
 		}
+	});
+
+	it("restores deleted artifacts without rerunning the build", async () => {
+		const libPath = join(testDir, "packages", "lib");
+		writeFileSync(
+			join(libPath, "package.json"),
+			JSON.stringify({
+				name: "@test/lib",
+				version: "1.0.0",
+				files: ["dist"],
+				scripts: {
+					build: "mkdir -p dist && echo run >> build-count && echo artifact > dist/index.js",
+				},
+			}),
+		);
+		await buildCommand({ filter: "@test/lib" });
+		rmSync(join(libPath, "dist"), { recursive: true, force: true });
+		await buildCommand({ filter: "@test/lib" });
+		expect(readFileSync(join(libPath, "build-count"), "utf8").trim()).toBe("run");
+		expect(readFileSync(join(libPath, "dist", "index.js"), "utf8").trim()).toBe("artifact");
 	});
 });

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -5,13 +5,19 @@ import {
 	validatePackagesHaveScript,
 	prepareCommandExecution,
 } from "../utils/package-utils.ts";
-import { ProcessRunner } from "../core/process-runner.ts";
 import { BuildCache } from "../core/cache.ts";
 import { Output } from "../utils/output.ts";
 import type { PackageInfo } from "../core/workspace.ts";
+import {
+	resolveTargets,
+	parsePositiveInteger,
+	parseDuration,
+	type CommonCommandOptions,
+} from "../utils/command-options.ts";
+import { runTopological } from "../core/scheduler.ts";
+import { emitEvent, isJsonReporter } from "../core/reporter.ts";
 
-interface BuildCommandOptions {
-	filter?: string;
+interface BuildCommandOptions extends CommonCommandOptions {
 	concurrency?: string;
 	skipUnchanged?: boolean;
 }
@@ -29,7 +35,12 @@ function collectPackagesWithDependencies(
 
 		collected.set(pkg.name, pkg);
 
-		const dependencies = [...pkg.dependencies, ...pkg.devDependencies];
+		const dependencies = [
+			...pkg.dependencies,
+			...pkg.devDependencies,
+			...(pkg.optionalDependencies || []),
+			...(pkg.peerDependencies || []),
+		];
 		for (const depName of dependencies) {
 			const depPackage = packageMap.get(depName);
 			if (depPackage && !collected.has(depName)) {
@@ -48,6 +59,12 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 		// Parse workspace
 		const parser = new WorkspaceParser();
 		const workspace = await parser.parseWorkspace();
+		if (isJsonReporter())
+			emitEvent("workspace", {
+				root: workspace.root,
+				packageManager: workspace.packageManager.name,
+				packageCount: workspace.packages.length,
+			});
 
 		Output.dim(`Workspace root: ${workspace.root}`, "folder");
 		Output.dim(`Found ${workspace.packages.length} packages\n`, "package");
@@ -59,19 +76,16 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 
 		if (options.skipUnchanged !== false) {
 			cache = new BuildCache(workspace.root);
-			await cache.initialize();
+			await cache.initialize(Boolean(options.dryRun));
 			Output.log("Build cache enabled - checking for unchanged packages...", "chart", "blue");
 		}
 
 		// Filter packages if pattern provided
-		let targetPackages = workspace.packages;
-		if (options.filter) {
-			targetPackages = parser.filterPackages(workspace.packages, options.filter);
-			Output.log(
-				`Filtered to ${targetPackages.length} packages matching "${options.filter}"`,
-				"magnifying",
-				"yellow",
-			);
+		let targetPackages = resolveTargets(workspace, options);
+		if (isJsonReporter())
+			emitEvent("selection", { packages: targetPackages.map((pkg) => pkg.name) });
+		if (options.filter?.length || options.affected || options.since) {
+			Output.log(`Selected ${targetPackages.length} packages`, "magnifying", "yellow");
 		}
 
 		// Validate filtered packages have the build script
@@ -108,11 +122,52 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 		// Check cache for each package (if enabled)
 		if (cache && options.skipUnchanged !== false) {
 			for (const pkg of packagesWithBuild) {
-				const isCached = await cache.isValid(pkg);
-				if (isCached) {
+				const decision = await cache.getDecision(pkg);
+				if (isJsonReporter())
+					emitEvent(decision.status === "hit" ? "cache_hit" : "cache_miss", {
+						packageName: pkg.name,
+						status: decision.status,
+					});
+				if (decision.status === "non-cacheable")
+					Output.warning(
+						`${pkg.name} has no inferable package artifacts and will not be cached`,
+					);
+				else if (decision.status === "corrupt")
+					Output.warning(`${pkg.name} has a corrupt artifact entry and will be rebuilt`);
+				const restored =
+					decision.status === "hit" && !options.dryRun
+						? await cache.restore(pkg, decision)
+						: decision.status === "hit";
+				if (restored && isJsonReporter())
+					emitEvent("artifact_restore", {
+						packageName: pkg.name,
+						inputHash: decision.inputHash,
+						dryRun: Boolean(options.dryRun),
+					});
+				if (restored) {
 					skippedPackages.push(pkg);
 				} else {
 					packagesToBuild.push(pkg);
+				}
+			}
+			// A rebuilt dependency always forces its cached dependents to rebuild.
+			const changed = new Set(packagesToBuild.map((pkg) => pkg.name));
+			let expanded = true;
+			while (expanded) {
+				expanded = false;
+				for (const pkg of Array.from(skippedPackages)) {
+					const deps = [
+						...pkg.dependencies,
+						...pkg.devDependencies,
+						...(pkg.optionalDependencies || []),
+						...(pkg.peerDependencies || []),
+					];
+					if (deps.some((dep) => changed.has(dep))) {
+						skippedPackages.splice(skippedPackages.indexOf(pkg), 1);
+						packagesToBuild.push(pkg);
+						changed.add(pkg.name);
+						expanded = true;
+					}
 				}
 			}
 
@@ -128,6 +183,13 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 			}
 
 			if (packagesToBuild.length === 0) {
+				if (options.dryRun && isJsonReporter())
+					emitEvent("plan", {
+						dryRun: true,
+						batches: [],
+						restores: skippedPackages.map((pkg) => pkg.name),
+						concurrency: parsePositiveInteger(options.concurrency, "concurrency", 4),
+					});
 				Output.celebrate("All packages are up to date!");
 				return;
 			}
@@ -171,7 +233,9 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 		});
 		console.log();
 
-		const concurrency = parseInt(options.concurrency || "4", 10);
+		const concurrency = parsePositiveInteger(options.concurrency, "concurrency", 4);
+		const retries = parsePositiveInteger(options.retry, "retry", 0, true);
+		const timeoutMs = parseDuration(options.timeout);
 
 		Output.log(`Package manager: ${workspace.packageManager.name}`, "wrench", "blue");
 		Output.log(`Batch concurrency: ${concurrency}`, "lightning", "blue");
@@ -191,29 +255,43 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 					);
 					return commands[0];
 				})
-				.filter((cmd): cmd is NonNullable<typeof cmd> => cmd !== undefined);
+				.filter((cmd): cmd is NonNullable<typeof cmd> => cmd !== undefined)
+				.map((cmd) => ({ ...cmd, options: { ...cmd.options, retries, timeoutMs } }));
 		});
+		if (options.dryRun) {
+			Output.info("Dry run build plan:");
+			if (isJsonReporter())
+				emitEvent("plan", { dryRun: true, batches: buildBatches, concurrency });
+			commandBatches
+				.flat()
+				.forEach((c) =>
+					Output.listItem(`${c.logOptions.prefix}: ${c.command} ${c.args.join(" ")}`),
+				);
+			return;
+		}
 
 		// Execute builds in batches
 		const startTime = Date.now();
-		const allResults = await ProcessRunner.runBatches(commandBatches, concurrency);
+		const scheduled = await runTopological(
+			commandBatches.flat(),
+			filteredGraph,
+			concurrency,
+			options,
+		);
+		const allResults = scheduled.results;
+		scheduled.cancelled.forEach((name) => Output.warning(`Cancelled after failure: ${name}`));
 		const totalDuration = Date.now() - startTime;
 
 		// Update cache for successful builds
 		if (cache && options.skipUnchanged !== false) {
 			const successfulBuilds = allResults.filter((r) => r.success);
-			const allPackagesMap = new Map(workspace.packages.map((pkg) => [pkg.name, pkg]));
-
 			for (const result of successfulBuilds) {
 				const pkg = packageMap.get(result.packageName);
 				if (pkg) {
-					await cache.update(pkg, allPackagesMap, result.duration);
+					const stored = await cache.storeArtifacts(pkg, result.duration);
+					if (stored && isJsonReporter())
+						emitEvent("artifact_store", { packageName: pkg.name });
 				}
-			}
-
-			// Invalidate dependents of rebuilt packages (conservative approach)
-			for (const result of successfulBuilds) {
-				cache.invalidateDependents(result.packageName, workspace.packages);
 			}
 
 			Output.log(`Updated cache for ${successfulBuilds.length} packages`, "chart", "blue");
@@ -225,12 +303,19 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 		const totalPackages = successful.length + skippedPackages.length;
 
 		Output.buildSummary(totalPackages, failed.length, totalDuration);
+		if (isJsonReporter())
+			emitEvent("summary", {
+				successful: totalPackages,
+				failed: failed.length,
+				blocked: scheduled.blocked.length,
+				duration: totalDuration,
+			});
 
 		if (skippedPackages.length > 0) {
 			Output.dim(`Skipped (cached): ${skippedPackages.length} packages`, "checkmark");
 		}
 
-		if (failed.length > 0) {
+		if (failed.length > 0 || scheduled.blocked.length > 0) {
 			console.log(pc.red("\nFailed packages:"));
 			failed.forEach((f) => {
 				Output.listItem(`${f.packageName} (exit code ${f.exitCode})`);
@@ -260,7 +345,7 @@ export async function buildCommand(options: BuildCommandOptions): Promise<void> 
 		}
 
 		// Exit with error code if any builds failed
-		if (failed.length > 0) {
+		if (failed.length > 0 || scheduled.blocked.length > 0) {
 			Output.log("\nBuild failed due to package failures.", "fire", "red");
 			process.exit(1);
 		} else {

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -69,6 +69,10 @@ async function showCacheStatus(cache: BuildCache, packages: { name: string }[]):
 	}
 
 	Output.success(`Cached packages: ${stats.totalPackages}`);
+	Output.dim(`Restorable artifacts: ${stats.artifactCount}`, "package");
+	Output.dim(`Artifact size: ${stats.artifactSize} bytes`, "folder");
+	Output.dim(`Metadata-only entries: ${stats.metadataOnly}`, "package");
+	if (stats.corrupt) Output.warning(`Corrupt artifact files: ${stats.corrupt}`);
 	Output.dim(`Cache last updated: ${new Date(stats.lastUpdated).toLocaleString()}`, "clock");
 
 	if (stats.oldestBuild && stats.newestBuild) {

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -3,10 +3,9 @@ import { existsSync } from "fs";
 import { join } from "path";
 import { WorkspaceParser } from "../core/workspace.ts";
 import { Output } from "../utils/output.ts";
+import { resolveTargets, type CommonCommandOptions } from "../utils/command-options.ts";
 
-interface CleanCommandOptions {
-	filter?: string;
-}
+interface CleanCommandOptions extends CommonCommandOptions {}
 
 export async function cleanCommand(options: CleanCommandOptions): Promise<void> {
 	try {
@@ -20,14 +19,9 @@ export async function cleanCommand(options: CleanCommandOptions): Promise<void> 
 		Output.dim(`Found ${workspace.packages.length} packages\n`, "package");
 
 		// Filter packages if pattern provided
-		let targetPackages = workspace.packages;
-		if (options.filter) {
-			targetPackages = parser.filterPackages(workspace.packages, options.filter);
-			Output.log(
-				`Filtered to ${targetPackages.length} packages matching "${options.filter}"`,
-				"magnifying",
-				"yellow",
-			);
+		let targetPackages = resolveTargets(workspace, options);
+		if (options.filter?.length) {
+			Output.log(`Filtered to ${targetPackages.length} packages`, "magnifying", "yellow");
 		}
 
 		const startTime = Date.now();
@@ -35,11 +29,11 @@ export async function cleanCommand(options: CleanCommandOptions): Promise<void> 
 		let skipped = 0;
 
 		// Clean root node_modules first (only if no filter)
-		if (!options.filter) {
+		if (!options.filter?.length && !options.affected && !options.since) {
 			const rootNodeModules = join(workspace.root, "node_modules");
 			if (existsSync(rootNodeModules)) {
 				Output.log(`Removing ${rootNodeModules}`, "fire", "yellow");
-				await rm(rootNodeModules, { recursive: true, force: true });
+				if (!options.dryRun) await rm(rootNodeModules, { recursive: true, force: true });
 				cleaned++;
 			}
 		}
@@ -50,7 +44,7 @@ export async function cleanCommand(options: CleanCommandOptions): Promise<void> 
 
 			if (existsSync(nodeModulesPath)) {
 				Output.log(`Removing ${pkg.name}/node_modules`, "fire", "yellow");
-				await rm(nodeModulesPath, { recursive: true, force: true });
+				if (!options.dryRun) await rm(nodeModulesPath, { recursive: true, force: true });
 				cleaned++;
 			} else {
 				skipped++;

--- a/src/commands/graph.ts
+++ b/src/commands/graph.ts
@@ -1,0 +1,63 @@
+import { relative } from "path";
+import { WorkspaceParser } from "../core/workspace.ts";
+import { selectPackages, getAllDependencies } from "../core/selection.ts";
+import { findAffectedPackages } from "../core/affected.ts";
+import { Output } from "../utils/output.ts";
+
+interface GraphOptions {
+	filter?: string[];
+	affected?: boolean;
+	since?: string;
+	format?: string;
+	dryRun?: boolean;
+}
+
+export async function graphCommand(options: GraphOptions): Promise<void> {
+	try {
+		const workspace = await new WorkspaceParser().parseWorkspace();
+		let selected = selectPackages(workspace, options.filter || []).packages;
+		const affected =
+			options.affected || options.since
+				? findAffectedPackages(workspace, { since: options.since })
+				: undefined;
+		if (affected) selected = selected.filter((p) => affected.has(p.name));
+		const names = new Set(selected.map((p) => p.name));
+		const nodes = selected.map((p) => ({
+			name: p.isRoot ? "root" : p.name,
+			packageName: p.name,
+			path: relative(workspace.root, p.path) || ".",
+			scripts: Object.keys(p.scripts),
+			selected: true,
+			affected: affected?.has(p.name) || false,
+			root: Boolean(p.isRoot),
+		}));
+		const edges = selected.flatMap((p) =>
+			getAllDependencies(p)
+				.filter((d) => names.has(d))
+				.map((dependency) => ({ from: p.name, to: dependency })),
+		);
+		const format = options.format || "text";
+		if (format === "json") console.log(JSON.stringify({ nodes, edges }, null, 2));
+		else if (format === "dot") {
+			console.log("digraph workspace {");
+			for (const node of nodes) console.log(`  ${JSON.stringify(node.packageName)};`);
+			for (const edge of edges)
+				console.log(`  ${JSON.stringify(edge.from)} -> ${JSON.stringify(edge.to)};`);
+			console.log("}");
+		} else if (format === "text") {
+			Output.info("Workspace dependency graph");
+			for (const node of nodes)
+				Output.log(
+					`${node.packageName}${node.root ? " (root)" : ""} -> ${
+						edges
+							.filter((e) => e.from === node.packageName)
+							.map((e) => e.to)
+							.join(", ") || "(none)"
+					}`,
+				);
+		} else throw new Error(`Unknown graph format: ${format}`);
+	} catch (error) {
+		Output.error(error instanceof Error ? error.message : String(error));
+		process.exitCode = 1;
+	}
+}

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -3,12 +3,21 @@ import { WorkspaceParser } from "../core/workspace.ts";
 import { validatePackagesHaveScript, prepareCommandExecution } from "../utils/package-utils.ts";
 import { ProcessRunner } from "../core/process-runner.ts";
 import { Output } from "../utils/output.ts";
+import {
+	resolveTargets,
+	parsePositiveInteger,
+	parseDuration,
+	type CommonCommandOptions,
+} from "../utils/command-options.ts";
+import { buildDependencyGraph } from "../utils/package-utils.ts";
+import { runTopological } from "../core/scheduler.ts";
+import { emitEvent, isJsonReporter } from "../core/reporter.ts";
 
-interface RunCommandOptions {
+interface RunCommandOptions extends CommonCommandOptions {
 	parallel?: boolean;
 	concurrency?: string;
-	filter?: string;
 	sequential?: boolean;
+	topological?: boolean;
 }
 
 export async function runCommand(scriptName: string, options: RunCommandOptions): Promise<void> {
@@ -18,31 +27,44 @@ export async function runCommand(scriptName: string, options: RunCommandOptions)
 		// Parse workspace
 		const parser = new WorkspaceParser();
 		const workspace = await parser.parseWorkspace();
+		if (isJsonReporter())
+			emitEvent("workspace", {
+				root: workspace.root,
+				packageManager: workspace.packageManager.name,
+				packageCount: workspace.packages.length,
+			});
 
 		Output.dim(`Workspace root: ${workspace.root}`, "folder");
 		Output.dim(`Found ${workspace.packages.length} packages\n`, "package");
 
 		// Filter packages if pattern provided
-		let targetPackages = workspace.packages;
-		if (options.filter) {
-			targetPackages = parser.filterPackages(workspace.packages, options.filter);
+		let targetPackages = resolveTargets(workspace, options);
+		if (options.topological && options.sequential)
+			throw new Error("--topological and --sequential are mutually exclusive");
+		if (options.filter?.length || options.affected || options.since) {
 			Output.log(
-				`Filtered to ${targetPackages.length} packages matching "${options.filter}"`,
+				options.filter && !Array.isArray(options.filter)
+					? `Filtered to ${targetPackages.length} packages matching "${options.filter}"`
+					: `Selected ${targetPackages.length} packages`,
 				"magnifying",
 				"yellow",
 			);
 		}
 
 		// Validate packages have the script
-		const { valid: packagesWithScript } = validatePackagesHaveScript(
-			targetPackages,
-			scriptName,
-		);
+		const { valid: packagesWithScript, invalid: packagesWithoutScript } =
+			validatePackagesHaveScript(targetPackages, scriptName);
+		if (packagesWithoutScript.length > 0) {
+			Output.warning(`Skipping packages without the "${scriptName}" script:`);
+			packagesWithoutScript.forEach((pkg) => Output.listItem(pkg.name));
+		}
 
 		if (packagesWithScript.length === 0) {
 			Output.error(`No packages found with the "${scriptName}" script.`);
 			process.exit(1);
 		}
+		if (isJsonReporter())
+			emitEvent("selection", { packages: packagesWithScript.map((pkg) => pkg.name) });
 
 		Output.success(`Running "${scriptName}" in ${packagesWithScript.length} packages:`);
 		packagesWithScript.forEach((pkg) => {
@@ -52,7 +74,9 @@ export async function runCommand(scriptName: string, options: RunCommandOptions)
 
 		// Determine execution mode (parallel by default unless explicitly sequential)
 		const isParallel = !options.sequential;
-		const concurrency = parseInt(options.concurrency || "4", 10);
+		const concurrency = parsePositiveInteger(options.concurrency, "concurrency", 4);
+		const retries = parsePositiveInteger(options.retry, "retry", 0, true);
+		const timeoutMs = parseDuration(options.timeout);
 
 		Output.log(`Package manager: ${workspace.packageManager.name}`, "wrench", "blue");
 		Output.log(
@@ -67,16 +91,54 @@ export async function runCommand(scriptName: string, options: RunCommandOptions)
 			packagesWithScript,
 			scriptName,
 			workspace.packageManager,
-		);
+		).map((command) => ({ ...command, options: { ...command.options, retries, timeoutMs } }));
+		if (options.dryRun) {
+			Output.info("Dry run execution plan:");
+			const batches = options.topological
+				? buildDependencyGraph(packagesWithScript).getBuildBatches()
+				: [packagesWithScript.map((pkg) => pkg.name)];
+			if (isJsonReporter())
+				emitEvent("plan", {
+					dryRun: true,
+					batches,
+					concurrency,
+					failurePolicy: options.failFast
+						? "fail-fast"
+						: options.continueOnError
+							? "continue"
+							: "block-downstream",
+				});
+			else
+				batches.forEach((batch, index) =>
+					Output.listItem(`Batch ${index + 1}: ${batch.join(", ")}`),
+				);
+			commands.forEach((c) =>
+				Output.listItem(`${c.logOptions.prefix}: ${c.command} ${c.args.join(" ")}`),
+			);
+			return;
+		}
 
 		// Execute commands
 		const startTime = Date.now();
 		let results;
 
-		if (isParallel) {
-			results = await ProcessRunner.runParallel(commands, concurrency);
+		let blocked: string[] = [];
+		if (options.topological) {
+			const scheduled = await runTopological(
+				commands,
+				buildDependencyGraph(packagesWithScript),
+				concurrency,
+				options,
+			);
+			results = scheduled.results;
+			blocked = scheduled.blocked;
+			scheduled.cancelled.forEach((name) =>
+				Output.warning(`Cancelled after failure: ${name}`),
+			);
+		} else if (isParallel) {
+			results = await ProcessRunner.runParallel(commands, concurrency, options.failFast);
 		} else {
-			results = await ProcessRunner.runSequential(commands);
+			results = await ProcessRunner.runSequential(commands, options.continueOnError);
 		}
 
 		const totalDuration = Date.now() - startTime;
@@ -84,10 +146,18 @@ export async function runCommand(scriptName: string, options: RunCommandOptions)
 		// Print summary
 		const successful = results.filter((r) => r.success);
 		const failed = results.filter((r) => !r.success);
+		blocked.forEach((name) => Output.warning(`Blocked by failed dependency: ${name}`));
 
 		Output.executionSummary(successful.length, failed.length, totalDuration);
+		if (isJsonReporter())
+			emitEvent("summary", {
+				successful: successful.length,
+				failed: failed.length,
+				blocked: blocked.length,
+				duration: totalDuration,
+			});
 
-		if (failed.length > 0) {
+		if (failed.length > 0 || blocked.length > 0) {
 			console.log(pc.red("\nFailed packages:"));
 			failed.forEach((f) => {
 				Output.listItem(`${f.packageName} (exit code ${f.exitCode})`);
@@ -102,7 +172,7 @@ export async function runCommand(scriptName: string, options: RunCommandOptions)
 		}
 
 		// Exit with error code if any commands failed
-		if (failed.length > 0) {
+		if (failed.length > 0 || blocked.length > 0) {
 			process.exit(1);
 		}
 	} catch (error) {

--- a/src/core/affected.test.ts
+++ b/src/core/affected.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "child_process";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { findAffectedPackages } from "./affected.ts";
+import type { PackageInfo, WorkspaceInfo } from "./workspace.ts";
+
+const root = join(process.cwd(), "test-temp-affected");
+const run = (args: string[]) => execFileSync("git", args, { cwd: root, stdio: "ignore" });
+
+describe("affected packages", () => {
+	afterEach(() => {
+		if (existsSync(root)) rmSync(root, { recursive: true, force: true });
+	});
+	it("includes changed packages and transitive dependents", () => {
+		mkdirSync(join(root, "packages", "core"), { recursive: true });
+		mkdirSync(join(root, "packages", "app"), { recursive: true });
+		writeFileSync(join(root, "packages", "core", "index.ts"), "one");
+		writeFileSync(join(root, "packages", "app", "index.ts"), "app");
+		run(["init", "-b", "main"]);
+		run(["config", "user.email", "test@example.com"]);
+		run(["config", "user.name", "Test"]);
+		run(["add", "."]);
+		run(["commit", "-m", "initial"]);
+		const base = execFileSync("git", ["rev-parse", "HEAD"], {
+			cwd: root,
+			encoding: "utf8",
+		}).trim();
+		writeFileSync(join(root, "packages", "core", "index.ts"), "two");
+		const core: PackageInfo = {
+			name: "core",
+			path: join(root, "packages", "core"),
+			packageJson: { name: "core" },
+			dependencies: [],
+			devDependencies: [],
+			scripts: {},
+		};
+		const app: PackageInfo = {
+			name: "app",
+			path: join(root, "packages", "app"),
+			packageJson: { name: "app" },
+			dependencies: ["core"],
+			devDependencies: [],
+			scripts: {},
+		};
+		const workspace: WorkspaceInfo = {
+			root,
+			packages: [core, app],
+			packageMap: new Map([
+				["core", core],
+				["app", app],
+			]),
+			packageManager: {} as WorkspaceInfo["packageManager"],
+		};
+		expect(findAffectedPackages(workspace, { since: base })).toEqual(new Set(["core", "app"]));
+	});
+});

--- a/src/core/affected.ts
+++ b/src/core/affected.ts
@@ -1,0 +1,94 @@
+import { execFileSync } from "child_process";
+import { relative, sep } from "path";
+import type { PackageInfo, WorkspaceInfo } from "./workspace.ts";
+import { getAllDependencies } from "./selection.ts";
+
+export interface AffectedOptions {
+	since?: string;
+}
+
+function git(root: string, args: string[]): string {
+	return execFileSync("git", args, {
+		cwd: root,
+		encoding: "utf8",
+		stdio: ["ignore", "pipe", "ignore"],
+	}).trim();
+}
+
+export function findAffectedPackages(
+	workspace: WorkspaceInfo,
+	options: AffectedOptions = {},
+): Set<string> {
+	let base = options.since;
+	if (!base) {
+		const candidates: string[] = [];
+		try {
+			candidates.push(
+				git(workspace.root, [
+					"symbolic-ref",
+					"--quiet",
+					"--short",
+					"refs/remotes/origin/HEAD",
+				]),
+			);
+		} catch {}
+		candidates.push("origin/main", "origin/master");
+		for (const candidate of candidates) {
+			try {
+				base = git(workspace.root, ["merge-base", "HEAD", candidate]);
+				if (base) break;
+			} catch {}
+		}
+		if (!base) throw new Error("Unable to determine a Git merge base; pass --since <ref>");
+	} else {
+		try {
+			base = git(workspace.root, ["merge-base", "HEAD", base]);
+		} catch {
+			throw new Error(`Unable to resolve Git ref: ${options.since}`);
+		}
+	}
+	const files = new Set<string>();
+	for (const args of [
+		["diff", "--name-only", `${base}..HEAD`],
+		["diff", "--name-only"],
+		["diff", "--cached", "--name-only"],
+		["ls-files", "--others", "--exclude-standard"],
+	]) {
+		try {
+			for (const file of git(workspace.root, args).split("\n").filter(Boolean))
+				files.add(file);
+		} catch {}
+	}
+	const global =
+		/^(package\.json|(?:bun\.lockb?|pnpm-lock\.yaml|pnpm-workspace\.yaml|package-lock\.json|yarn\.lock|\.yarnrc\.yml|\.npmrc|bunfig\.toml)|tsconfig[^/]*\.json|[^/]+\.config\.[^/]+)$/;
+	if ([...files].some((f) => global.test(f)))
+		return new Set([
+			...workspace.packages.map((p) => p.name),
+			...(workspace.rootPackage ? [workspace.rootPackage.name] : []),
+		]);
+	const affected = new Set<string>();
+	for (const file of files) {
+		let best: PackageInfo | undefined;
+		for (const pkg of workspace.packages) {
+			const rel = relative(workspace.root, pkg.path).split(sep).join("/");
+			if (
+				(file === rel || file.startsWith(`${rel}/`)) &&
+				(!best || pkg.path.length > best.path.length)
+			)
+				best = pkg;
+		}
+		if (best) affected.add(best.name);
+	}
+	const reverse = new Map<string, string[]>();
+	for (const pkg of workspace.packages)
+		for (const dep of getAllDependencies(pkg))
+			reverse.set(dep, [...(reverse.get(dep) || []), pkg.name]);
+	const queue = [...affected];
+	while (queue.length)
+		for (const dep of reverse.get(queue.shift()!) || [])
+			if (!affected.has(dep)) {
+				affected.add(dep);
+				queue.push(dep);
+			}
+	return affected;
+}

--- a/src/core/cache.test.ts
+++ b/src/core/cache.test.ts
@@ -342,6 +342,31 @@ describe("BuildCache", () => {
 			expect(stats.newestBuild).toBeDefined();
 		});
 	});
+
+	describe("artifacts", () => {
+		it("stores and restores inferred build outputs", async () => {
+			const pkg: PackageInfo = {
+				name: "artifact-pkg",
+				path: join(testDir, "artifact-pkg"),
+				packageJson: { name: "artifact-pkg", files: ["dist"], scripts: { build: "build" } },
+				scripts: { build: "build" },
+				dependencies: [],
+				devDependencies: [],
+			};
+			mkdirSync(join(pkg.path, "src"), { recursive: true });
+			mkdirSync(join(pkg.path, "dist"), { recursive: true });
+			writeFileSync(join(pkg.path, "package.json"), JSON.stringify(pkg.packageJson));
+			writeFileSync(join(pkg.path, "src", "index.ts"), "source");
+			writeFileSync(join(pkg.path, "dist", "index.js"), "artifact");
+
+			expect(await cache.storeArtifacts(pkg, 10)).toBe(true);
+			rmSync(join(pkg.path, "dist"), { recursive: true, force: true });
+			const decision = await cache.getDecision(pkg);
+			expect(decision.status).toBe("hit");
+			expect(await cache.restore(pkg, decision)).toBe(true);
+			expect(readFileSync(join(pkg.path, "dist", "index.js"), "utf8")).toBe("artifact");
+		});
+	});
 });
 
 import { readFileSync } from "fs";

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -7,22 +7,28 @@ import {
 	appendFileSync,
 	statSync,
 	rmSync,
+	cpSync,
+	renameSync,
+	lstatSync,
+	chmodSync,
 } from "fs";
-import { join, relative } from "path";
+import { join, relative, resolve, dirname, isAbsolute, normalize } from "path";
 import { promisify } from "util";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import fg from "fast-glob";
 import type { PackageInfo } from "./workspace.ts";
 import { Output } from "../utils/output.ts";
+import { PackageManagerDetector } from "../package-managers/detector.ts";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
-const CACHE_VERSION = 2; // Bumped for new structure
+const CACHE_VERSION = 3;
 const CACHE_DIR_NAME = ".wsu";
 const PACKAGES_DIR = "packages";
 const CACHE_FILE = "cache.json";
 const FILES_FILE = "files.json";
 const MANIFEST_FILE = "manifest.json";
+const ARTIFACTS_DIR = "artifacts";
 
 // Per-package file metadata
 interface FileMetadata {
@@ -42,6 +48,38 @@ export interface CacheEntry {
 	lastBuild: string;
 	buildDuration: number;
 	builtBy: string;
+	artifactHash?: string;
+	artifactFiles?: ArtifactFile[];
+}
+
+export interface ArtifactDeclaration {
+	pattern: string;
+	kind: "file" | "glob";
+	exclude?: boolean;
+}
+export interface ArtifactFile {
+	path: string;
+	hash: string;
+	mode: number;
+}
+export interface ArtifactManifest {
+	version: number;
+	packageName: string;
+	taskName: string;
+	inputHash: string;
+	artifactHash: string;
+	files: ArtifactFile[];
+	createdAt: string;
+	buildDuration: number;
+}
+export interface ArtifactCacheEntry extends CacheEntry {
+	artifactHash: string;
+	artifactFiles: ArtifactFile[];
+}
+export interface CacheDecision {
+	status: "hit" | "miss" | "non-cacheable" | "corrupt";
+	inputHash: string;
+	declarations: ArtifactDeclaration[];
 }
 
 // Manifest tracks all cached packages (for quick lookups)
@@ -74,17 +112,17 @@ export class BuildCache {
 	/**
 	 * Initialize cache - create directory structure and ensure .gitignore
 	 */
-	async initialize(): Promise<void> {
+	async initialize(readOnly = false): Promise<void> {
 		if (this.initialized) return;
 
 		// Create .wsu directory
-		if (!existsSync(this.baseCacheDir)) {
+		if (!readOnly && !existsSync(this.baseCacheDir)) {
 			mkdirSync(this.baseCacheDir, { recursive: true });
 			Output.dim(`Created ${CACHE_DIR_NAME}/ directory`, "folder");
 		}
 
 		// Ensure .wsu is in .gitignore
-		await this.ensureGitignore();
+		if (!readOnly) await this.ensureGitignore();
 
 		// Load manifest
 		this.loadManifest();
@@ -97,6 +135,180 @@ export class BuildCache {
 	 */
 	private getPackageCacheDir(packageName: string): string {
 		return join(this.baseCacheDir, PACKAGES_DIR, packageName);
+	}
+
+	private safePackageKey(packageName: string): string {
+		return Buffer.from(packageName).toString("base64url");
+	}
+
+	private getArtifactDir(packageName: string, inputHash: string): string {
+		return join(this.baseCacheDir, ARTIFACTS_DIR, this.safePackageKey(packageName), inputHash);
+	}
+
+	inferArtifactDeclarations(pkg: PackageInfo): ArtifactDeclaration[] {
+		const values: string[] = [];
+		const json = pkg.packageJson;
+		if (Array.isArray(json.files))
+			values.push(...json.files.filter((v): v is string => typeof v === "string"));
+		for (const key of ["main", "module", "types", "typings"] as const)
+			if (typeof json[key] === "string") values.push(json[key] as string);
+		if (typeof json.bin === "string") values.push(json.bin);
+		else if (json.bin && typeof json.bin === "object")
+			values.push(
+				...Object.values(json.bin as Record<string, unknown>).filter(
+					(v): v is string => typeof v === "string",
+				),
+			);
+		const visit = (value: unknown): void => {
+			if (typeof value === "string") values.push(value);
+			else if (value && typeof value === "object")
+				Object.values(value as Record<string, unknown>).forEach(visit);
+		};
+		visit(json.exports);
+		const declarations = new Map<string, ArtifactDeclaration>();
+		for (let value of values) {
+			const exclude = value.startsWith("!");
+			if (exclude) value = value.slice(1);
+			if (/^[a-z]+:/i.test(value) || value.startsWith("#")) continue;
+			value = value.replace(/^\.\//, "").replace(/\\/g, "/");
+			if (
+				!value ||
+				isAbsolute(value) ||
+				normalize(value).startsWith("..") ||
+				/(^|\/)(node_modules|\.git|\.wsu)(\/|$)/.test(value)
+			)
+				throw new Error(`Unsafe artifact path in ${pkg.name}: ${value}`);
+			declarations.set(`${exclude ? "!" : ""}${value}`, {
+				pattern: value,
+				kind: fg.isDynamicPattern(value) ? "glob" : "file",
+				exclude,
+			});
+		}
+		return [...declarations.values()];
+	}
+
+	private async artifactFiles(
+		pkg: PackageInfo,
+		declarations: ArtifactDeclaration[],
+	): Promise<string[]> {
+		const patterns = declarations.map((d) => {
+			const path = join(pkg.path, d.pattern);
+			const pattern =
+				d.kind === "file" && existsSync(path) && statSync(path).isDirectory()
+					? `${d.pattern.replace(/\/$/, "")}/**/*`
+					: d.pattern;
+			return d.exclude ? `!${pattern}` : pattern;
+		});
+		if (!patterns.length) return [];
+		return (
+			await fg(patterns, {
+				cwd: pkg.path,
+				onlyFiles: true,
+				dot: true,
+				followSymbolicLinks: false,
+			})
+		).sort();
+	}
+
+	async getDecision(pkg: PackageInfo): Promise<CacheDecision> {
+		const declarations = this.inferArtifactDeclarations(pkg);
+		const inputHash = await this.calculatePackageHash(pkg, declarations);
+		if (!declarations.some((declaration) => !declaration.exclude))
+			return { status: "non-cacheable", inputHash, declarations };
+		const entry = this.packageCaches.get(pkg.name);
+		if (!entry || entry.inputHash !== inputHash || !entry.artifactFiles?.length)
+			return { status: "miss", inputHash, declarations };
+		const dir = this.getArtifactDir(pkg.name, inputHash);
+		for (const file of entry.artifactFiles)
+			if (!existsSync(join(dir, "files", file.path)))
+				return { status: "corrupt", inputHash, declarations };
+		return { status: "hit", inputHash, declarations };
+	}
+
+	async restore(pkg: PackageInfo, decision?: CacheDecision): Promise<boolean> {
+		const resolved = decision || (await this.getDecision(pkg));
+		if (resolved.status !== "hit") return false;
+		const entry = this.packageCaches.get(pkg.name)!;
+		for (const declaration of resolved.declarations) {
+			if (declaration.exclude) continue;
+			if (declaration.kind === "file")
+				rmSync(join(pkg.path, declaration.pattern), { recursive: true, force: true });
+			else
+				for (const match of await fg(declaration.pattern, {
+					cwd: pkg.path,
+					onlyFiles: false,
+					dot: true,
+				}))
+					rmSync(join(pkg.path, match), { recursive: true, force: true });
+		}
+		const source = join(this.getArtifactDir(pkg.name, resolved.inputHash), "files");
+		for (const file of entry.artifactFiles || []) {
+			const target = resolve(pkg.path, file.path);
+			if (!target.startsWith(resolve(pkg.path) + "/")) return false;
+			mkdirSync(dirname(target), { recursive: true });
+			cpSync(join(source, file.path), target, { dereference: false });
+			chmodSync(target, file.mode);
+			if (
+				this.hashFile(target, { version: CACHE_VERSION, files: {} }, file.path) !==
+				file.hash
+			)
+				return false;
+		}
+		return true;
+	}
+
+	async storeArtifacts(pkg: PackageInfo, buildDuration: number): Promise<boolean> {
+		const declarations = this.inferArtifactDeclarations(pkg);
+		if (!declarations.some((declaration) => !declaration.exclude)) return false;
+		const files = await this.artifactFiles(pkg, declarations);
+		if (!files.length) return false;
+		const inputHash = await this.calculatePackageHash(pkg, declarations);
+		const finalDir = this.getArtifactDir(pkg.name, inputHash);
+		const tempDir = `${finalDir}.tmp-${process.pid}-${Date.now()}`;
+		mkdirSync(join(tempDir, "files"), { recursive: true });
+		const artifactFiles: ArtifactFile[] = [];
+		for (const file of files) {
+			const source = join(pkg.path, file);
+			const target = join(tempDir, "files", file);
+			mkdirSync(dirname(target), { recursive: true });
+			cpSync(source, target, { dereference: false });
+			const stats = lstatSync(source);
+			artifactFiles.push({
+				path: file,
+				hash: this.hashFile(source, { version: CACHE_VERSION, files: {} }, file),
+				mode: stats.mode,
+			});
+		}
+		const artifactHash = this.hashString(
+			artifactFiles.map((f) => `${f.path}:${f.hash}:${f.mode}`).join("\n"),
+		);
+		mkdirSync(dirname(finalDir), { recursive: true });
+		rmSync(finalDir, { recursive: true, force: true });
+		renameSync(tempDir, finalDir);
+		const dependencyHashes: Record<string, string | undefined> = {};
+		for (const depName of this.packageDependencies(pkg))
+			dependencyHashes[depName] = this.packageCaches.get(depName)?.inputHash;
+		this.savePackageCache(pkg.name, {
+			inputHash,
+			dependencyHashes,
+			lastBuild: new Date().toISOString(),
+			buildDuration,
+			builtBy: "wsu",
+			artifactHash,
+			artifactFiles,
+		});
+		return true;
+	}
+
+	private packageDependencies(pkg: PackageInfo): string[] {
+		return [
+			...new Set([
+				...pkg.dependencies,
+				...pkg.devDependencies,
+				...(pkg.optionalDependencies || []),
+				...(pkg.peerDependencies || []),
+			]),
+		];
 	}
 
 	/**
@@ -170,7 +382,9 @@ export class BuildCache {
 	 * Save manifest to disk
 	 */
 	private saveManifest(): void {
-		writeFileSync(this.manifestPath, JSON.stringify(this.manifest, null, 2), "utf8");
+		const temporary = `${this.manifestPath}.tmp-${process.pid}`;
+		writeFileSync(temporary, JSON.stringify(this.manifest, null, 2), "utf8");
+		renameSync(temporary, this.manifestPath);
 	}
 
 	/**
@@ -200,7 +414,9 @@ export class BuildCache {
 		}
 
 		const cachePath = this.getPackageCachePath(packageName);
-		writeFileSync(cachePath, JSON.stringify(entry, null, 2), "utf8");
+		const temporary = `${cachePath}.tmp-${process.pid}`;
+		writeFileSync(temporary, JSON.stringify(entry, null, 2), "utf8");
+		renameSync(temporary, cachePath);
 		this.packageCaches.set(packageName, entry);
 
 		// Update manifest
@@ -303,8 +519,9 @@ export class BuildCache {
 			const relativePaths = batch.map((f) => relative(this.workspaceRoot, f));
 
 			try {
-				const { stdout } = await execAsync(
-					`git check-ignore ${relativePaths.map((p) => `"${p}"`).join(" ")}`,
+				const { stdout } = await execFileAsync(
+					"git",
+					["check-ignore", "--", ...relativePaths],
 					{ cwd: this.workspaceRoot },
 				);
 
@@ -349,7 +566,10 @@ export class BuildCache {
 	/**
 	 * Calculate hash for a package
 	 */
-	async calculatePackageHash(pkg: PackageInfo): Promise<string> {
+	async calculatePackageHash(
+		pkg: PackageInfo,
+		declarations = this.inferArtifactDeclarations(pkg),
+	): Promise<string> {
 		const fileIndex = this.loadPackageFileIndex(pkg.name);
 
 		// Hash package.json
@@ -357,7 +577,20 @@ export class BuildCache {
 		const packageJsonHash = this.hashFile(packageJsonPath, fileIndex, "package.json");
 
 		// Hash source files
-		const sourceFiles = await this.getSourceFiles(pkg.path);
+		const sourceFiles = (await this.getSourceFiles(pkg.path)).filter(
+			(file) =>
+				!declarations.some((d) =>
+					d.exclude
+						? false
+						: d.kind === "glob"
+							? fg.isDynamicPattern(d.pattern) &&
+								fg
+									.sync(d.pattern, { cwd: pkg.path, onlyFiles: true })
+									.includes(file.relative)
+							: file.relative === d.pattern ||
+								file.relative.startsWith(`${d.pattern}/`),
+				),
+		);
 		const fileHashes: string[] = [];
 
 		for (const { path, relative: relPath } of sourceFiles) {
@@ -372,7 +605,7 @@ export class BuildCache {
 
 		// Get dependency hashes
 		const depHashes: string[] = [];
-		for (const depName of [...pkg.dependencies, ...pkg.devDependencies]) {
+		for (const depName of this.packageDependencies(pkg)) {
 			const depEntry = this.packageCaches.get(depName);
 			if (depEntry) {
 				depHashes.push(`${depName}:${depEntry.inputHash}`);
@@ -382,10 +615,46 @@ export class BuildCache {
 		}
 
 		// Combine all hashes
+		const globalPatterns = [
+			"package.json",
+			"bun.lock",
+			"bun.lockb",
+			"pnpm-lock.yaml",
+			"pnpm-workspace.yaml",
+			"package-lock.json",
+			"yarn.lock",
+			".yarnrc.yml",
+			".npmrc",
+			"bunfig.toml",
+			"tsconfig*.json",
+			"*.config.*",
+		];
+		const globalHashes: string[] = [];
+		for (const file of await fg(globalPatterns, { cwd: this.workspaceRoot, onlyFiles: true }))
+			globalHashes.push(
+				`${file}:${this.hashFile(join(this.workspaceRoot, file), fileIndex, `../${file}`)}`,
+			);
+		let packageManager = "unknown";
+		try {
+			const detected = PackageManagerDetector.detect(this.workspaceRoot).packageManager;
+			let version = "unknown";
+			try {
+				version = (
+					await execFileAsync(detected.name, ["--version"], { cwd: this.workspaceRoot })
+				).stdout.trim();
+			} catch {}
+			packageManager = `${detected.name}@${version}`;
+		} catch {}
 		const combined = [
+			`version:${CACHE_VERSION}`,
 			`packageJson:${packageJsonHash}`,
 			`sources:${fileHashes.join(",")}`,
 			`deps:${depHashes.sort().join(",")}`,
+			`global:${globalHashes.sort().join(",")}`,
+			`environment:${process.env.NODE_ENV || "development"}`,
+			`runtime:${process.versions.bun ? `bun@${process.versions.bun}` : `node@${process.version}`}`,
+			`packageManager:${packageManager}`,
+			`script:${pkg.scripts.build || ""}`,
 		].join("\n");
 
 		return this.hashString(combined);
@@ -416,7 +685,7 @@ export class BuildCache {
 
 		// Collect dependency hashes
 		const dependencyHashes: Record<string, string | undefined> = {};
-		for (const depName of [...pkg.dependencies, ...pkg.devDependencies]) {
+		for (const depName of this.packageDependencies(pkg)) {
 			const depEntry = this.packageCaches.get(depName);
 			dependencyHashes[depName] = depEntry?.inputHash;
 		}
@@ -459,8 +728,8 @@ export class BuildCache {
 	 * Invalidate a package and its dependents (conservative)
 	 */
 	invalidateDependents(packageName: string, packages: PackageInfo[]): void {
-		const dependents = packages.filter(
-			(p) => p.dependencies.includes(packageName) || p.devDependencies.includes(packageName),
+		const dependents = packages.filter((p) =>
+			this.packageDependencies(p).includes(packageName),
 		);
 
 		for (const dependent of dependents) {
@@ -486,6 +755,8 @@ export class BuildCache {
 		if (existsSync(packagesDir)) {
 			rmSync(packagesDir, { recursive: true, force: true });
 		}
+		const artifactsDir = join(this.baseCacheDir, ARTIFACTS_DIR);
+		if (existsSync(artifactsDir)) rmSync(artifactsDir, { recursive: true, force: true });
 	}
 
 	/**
@@ -496,10 +767,22 @@ export class BuildCache {
 		lastUpdated: string;
 		oldestBuild: string | null;
 		newestBuild: string | null;
+		artifactCount: number;
+		artifactSize: number;
+		metadataOnly: number;
+		corrupt: number;
 	} {
 		const entries = Array.from(this.packageCaches.values());
 		const timestamps = entries.map((e) => new Date(e.lastBuild).getTime()).sort();
 
+		let artifactSize = 0;
+		let corrupt = 0;
+		for (const [name, entry] of this.packageCaches)
+			for (const file of entry.artifactFiles || []) {
+				const path = join(this.getArtifactDir(name, entry.inputHash), "files", file.path);
+				if (existsSync(path)) artifactSize += statSync(path).size;
+				else corrupt++;
+			}
 		return {
 			totalPackages: entries.length,
 			lastUpdated: new Date().toISOString(),
@@ -508,6 +791,10 @@ export class BuildCache {
 				timestamps.length > 0
 					? new Date(timestamps[timestamps.length - 1]!).toISOString()
 					: null,
+			artifactCount: entries.filter((e) => e.artifactFiles?.length).length,
+			artifactSize,
+			metadataOnly: entries.filter((e) => !e.artifactFiles?.length).length,
+			corrupt,
 		};
 	}
 

--- a/src/core/process-runner.test.ts
+++ b/src/core/process-runner.test.ts
@@ -129,6 +129,36 @@ describe("ProcessRunner", () => {
 			// Should take longer with concurrency limit of 2
 			expect(endTime - startTime).toBeGreaterThanOrEqual(10);
 		});
+
+		it("should report each started task exactly once during fail-fast", async () => {
+			const commands = [
+				{
+					command: "false",
+					args: [],
+					options: { cwd: process.cwd() },
+					logOptions: { prefix: "failed", color: "red" },
+				},
+				{
+					command: "sleep",
+					args: ["5"],
+					options: { cwd: process.cwd() },
+					logOptions: { prefix: "active", color: "blue" },
+				},
+				{
+					command: "echo",
+					args: ["must not start"],
+					options: { cwd: process.cwd() },
+					logOptions: { prefix: "unscheduled", color: "yellow" },
+				},
+			];
+
+			const results = await ProcessRunner.runParallel(commands, 2, true);
+			const packageNames = results.map((result) => result.packageName);
+
+			expect(packageNames).toHaveLength(2);
+			expect(new Set(packageNames)).toEqual(new Set(["failed", "active"]));
+			expect(packageNames).not.toContain("unscheduled");
+		});
 	});
 
 	describe("runSequential", () => {

--- a/src/core/process-runner.ts
+++ b/src/core/process-runner.ts
@@ -1,16 +1,22 @@
 import { spawn, type ChildProcess } from "child_process";
 import pc from "picocolors";
+import { emitEvent, isJsonReporter } from "./reporter.ts";
 
 export interface ProcessOptions {
 	cwd: string;
 	env?: Record<string, string>;
 	stdio?: "inherit" | "pipe";
+	retries?: number;
+	timeoutMs?: number;
+	attempt?: number;
 }
 
 export interface LogOptions {
 	prefix: string;
 	color: string;
 	showTimestamp?: boolean;
+	taskName?: string;
+	attempt?: number;
 }
 
 export interface ProcessResult {
@@ -19,6 +25,8 @@ export interface ProcessResult {
 	packageName: string;
 	command: string;
 	duration: number;
+	signal?: NodeJS.Signals;
+	timedOut?: boolean;
 }
 
 export class ProcessRunner {
@@ -103,11 +111,43 @@ export class ProcessRunner {
 		options: ProcessOptions,
 		logOptions: LogOptions,
 	): Promise<ProcessResult> {
+		if ((options.retries || 0) > 0) {
+			let result: ProcessResult | undefined;
+			for (let attempt = 0; attempt <= (options.retries || 0); attempt++) {
+				result = await this.runCommand(
+					command,
+					args,
+					{ ...options, retries: 0, attempt: attempt + 1 },
+					{ ...logOptions, attempt: attempt + 1 },
+				);
+				if (result.success) return result;
+				if (result.signal && !result.timedOut) return result;
+				if (attempt < (options.retries || 0)) {
+					if (isJsonReporter())
+						emitEvent("task_retry", {
+							packageName: logOptions.prefix,
+							taskName: args[1] || args[0],
+							attempt: attempt + 2,
+						});
+					else console.log(`[${logOptions.prefix}] Retrying (attempt ${attempt + 2})`);
+				}
+			}
+			return result!;
+		}
 		const startTime = Date.now();
 		const fullCommand = [command, ...args].join(" ");
+		const attempt = options.attempt || 1;
+		const taskName = args[1] || args[0] || command;
 
 		const colorFn = this.getColorFn(logOptions.color);
-		console.log(`[${colorFn(logOptions.prefix)}] ` + pc.gray(`Starting: ${fullCommand}`));
+		if (isJsonReporter())
+			emitEvent("task_start", {
+				packageName: logOptions.prefix,
+				taskName,
+				command: fullCommand,
+				attempt,
+			});
+		else console.log(`[${colorFn(logOptions.prefix)}] ` + pc.gray(`Starting: ${fullCommand}`));
 
 		return new Promise((resolve) => {
 			const childProcess = spawn(command, args, {
@@ -118,6 +158,15 @@ export class ProcessRunner {
 
 			// Register child for potential global shutdown
 			ProcessRunner.activeChildren.add(childProcess);
+			let timedOut = false;
+			let forceTimeout: ReturnType<typeof setTimeout> | undefined;
+			const timeout = options.timeoutMs
+				? setTimeout(() => {
+						timedOut = true;
+						childProcess.kill("SIGTERM");
+						forceTimeout = setTimeout(() => childProcess.kill("SIGKILL"), 1000);
+					}, options.timeoutMs)
+				: undefined;
 
 			// Stream stdout with prefix and color
 			if (childProcess.stdout) {
@@ -143,11 +192,13 @@ export class ProcessRunner {
 				});
 			}
 
-			childProcess.on("close", (exitCode) => {
+			childProcess.on("close", (exitCode, signal) => {
+				if (timeout) clearTimeout(timeout);
+				if (forceTimeout) clearTimeout(forceTimeout);
 				// Deregister on close
 				ProcessRunner.activeChildren.delete(childProcess);
 				const duration = Date.now() - startTime;
-				const code = exitCode || 0;
+				const code = exitCode ?? (signal ? 1 : 0);
 
 				const result: ProcessResult = {
 					success: code === 0,
@@ -155,10 +206,24 @@ export class ProcessRunner {
 					packageName: logOptions.prefix,
 					command: fullCommand,
 					duration,
+					signal: signal || undefined,
+					timedOut,
 				};
 
 				const colorFn = this.getColorFn(logOptions.color);
-				if (code === 0) {
+				if (isJsonReporter())
+					emitEvent("task_complete", {
+						packageName: logOptions.prefix,
+						taskName,
+						command: fullCommand,
+						attempt,
+						exitCode: code,
+						success: code === 0,
+						duration,
+						signal,
+						timedOut,
+					});
+				else if (code === 0) {
 					console.log(
 						`[${colorFn(logOptions.prefix)}] ` +
 							pc.green(`✅ Completed in ${duration}ms`),
@@ -174,6 +239,8 @@ export class ProcessRunner {
 			});
 
 			childProcess.on("error", (error) => {
+				if (timeout) clearTimeout(timeout);
+				if (forceTimeout) clearTimeout(forceTimeout);
 				// Deregister on error
 				ProcessRunner.activeChildren.delete(childProcess);
 				const duration = Date.now() - startTime;
@@ -246,6 +313,15 @@ export class ProcessRunner {
 	 * Log a single line with prefix and color
 	 */
 	private static logLine(line: string, logOptions: LogOptions, isError = false): void {
+		if (isJsonReporter()) {
+			emitEvent(isError ? "task_stderr" : "task_stdout", {
+				packageName: logOptions.prefix,
+				taskName: logOptions.taskName,
+				attempt: logOptions.attempt || 1,
+				message: line,
+			});
+			return;
+		}
 		const timestamp = logOptions.showTimestamp ? pc.dim(`[${new Date().toISOString()}] `) : "";
 
 		// Only color the package name in brackets, not the entire line
@@ -269,6 +345,7 @@ export class ProcessRunner {
 			logOptions: LogOptions;
 		}>,
 		concurrency = 4,
+		failFast = false,
 	): Promise<ProcessResult[]> {
 		const results: ProcessResult[] = [];
 		const executing: Promise<ProcessResult>[] = [];
@@ -290,6 +367,11 @@ export class ProcessRunner {
 				if (completedPromise) {
 					const completed = await completedPromise;
 					results.push(completed);
+					if (failFast && !completed.success) {
+						executing.splice(completedIndex, 1);
+						await this.terminateAll();
+						break;
+					}
 				}
 
 				// Remove completed promise from executing array
@@ -325,6 +407,7 @@ export class ProcessRunner {
 			options: ProcessOptions;
 			logOptions: LogOptions;
 		}>,
+		continueOnError = false,
 	): Promise<ProcessResult[]> {
 		const results: ProcessResult[] = [];
 
@@ -339,7 +422,7 @@ export class ProcessRunner {
 			results.push(result);
 
 			// Stop on first failure unless explicitly configured to continue
-			if (!result.success) {
+			if (!result.success && !continueOnError) {
 				console.log(
 					pc.red(`\n❌ Stopping execution due to failure in ${result.packageName}`),
 				);

--- a/src/core/reporter.ts
+++ b/src/core/reporter.ts
@@ -1,0 +1,58 @@
+import { randomUUID } from "crypto";
+
+export type ExecutionEventType =
+	| "workspace"
+	| "selection"
+	| "plan"
+	| "task_start"
+	| "task_stdout"
+	| "task_stderr"
+	| "task_retry"
+	| "task_complete"
+	| "task_blocked"
+	| "cache_hit"
+	| "cache_miss"
+	| "artifact_restore"
+	| "artifact_store"
+	| "warning"
+	| "summary"
+	| "error";
+export interface ExecutionEvent {
+	schemaVersion: 1;
+	timestamp: string;
+	type: ExecutionEventType;
+	invocationId: string;
+	[key: string]: unknown;
+}
+export interface Reporter {
+	emit(event: ExecutionEvent): void;
+}
+
+const invocationId = randomUUID();
+let installed = false;
+const rawWrite = process.stdout.write.bind(process.stdout);
+
+export function emitEvent(type: ExecutionEventType, data: Record<string, unknown> = {}): void {
+	const event: ExecutionEvent = {
+		schemaVersion: 1,
+		timestamp: new Date().toISOString(),
+		type,
+		invocationId,
+		...data,
+	};
+	rawWrite(`${JSON.stringify(event)}\n`);
+}
+
+export function installJsonReporter(): void {
+	if (installed) return;
+	installed = true;
+	process.env.WSU_OUTPUT = "json";
+	console.log = (...args: unknown[]) =>
+		emitEvent("warning", { message: args.map(String).join(" ") });
+	console.error = (...args: unknown[]) =>
+		emitEvent("error", { message: args.map(String).join(" ") });
+}
+
+export function isJsonReporter(): boolean {
+	return process.env.WSU_OUTPUT === "json";
+}

--- a/src/core/scheduler.ts
+++ b/src/core/scheduler.ts
@@ -1,0 +1,96 @@
+import {
+	ProcessRunner,
+	type ProcessResult,
+	type ProcessOptions,
+	type LogOptions,
+} from "./process-runner.ts";
+import { DependencyGraph } from "./dependency-graph.ts";
+import { emitEvent, isJsonReporter } from "./reporter.ts";
+
+export interface TaskCommand {
+	command: string;
+	args: string[];
+	options: ProcessOptions;
+	logOptions: LogOptions;
+}
+export type TaskState = "pending" | "running" | "success" | "failed" | "blocked" | "cancelled";
+export interface TaskNode {
+	packageName: string;
+	taskName: string;
+	dependencies: string[];
+	state: TaskState;
+}
+export interface ExecutionPlan {
+	tasks: TaskNode[];
+	batches: string[][];
+	concurrency: number;
+	failurePolicy: FailurePolicy;
+}
+export interface FailurePolicy {
+	failFast?: boolean;
+	continueOnError?: boolean;
+}
+export interface ScheduledResult {
+	results: ProcessResult[];
+	blocked: string[];
+	cancelled: string[];
+}
+
+export async function runTopological(
+	commands: TaskCommand[],
+	graph: DependencyGraph,
+	concurrency: number,
+	policy: FailurePolicy = {},
+): Promise<ScheduledResult> {
+	const byName = new Map(commands.map((c) => [c.logOptions.prefix, c]));
+	const pending = new Set(byName.keys());
+	const states = new Map<string, "success" | "failed" | "blocked">();
+	const results: ProcessResult[] = [];
+	const blocked: string[] = [];
+	const cancelled: string[] = [];
+	graph.getBuildBatches(); // validates cycles before execution
+	while (pending.size) {
+		let progressed = false;
+		for (const name of Array.from(pending)) {
+			const deps = graph.getDependencies(name).filter((d) => byName.has(d));
+			if (
+				deps.some((d) => states.get(d) === "failed" || states.get(d) === "blocked") &&
+				!policy.continueOnError
+			) {
+				states.set(name, "blocked");
+				pending.delete(name);
+				blocked.push(name);
+				if (isJsonReporter())
+					emitEvent("task_blocked", { packageName: name, reason: "dependency_failed" });
+				progressed = true;
+			}
+		}
+		const ready = [...pending]
+			.filter((name) =>
+				graph
+					.getDependencies(name)
+					.filter((d) => byName.has(d))
+					.every((d) => states.has(d)),
+			)
+			.map((n) => byName.get(n)!);
+		if (!ready.length) {
+			if (!progressed) throw new Error("Unable to schedule tasks");
+			continue;
+		}
+		const batchResults = await ProcessRunner.runParallel(ready, concurrency, policy.failFast);
+		for (const result of batchResults) {
+			results.push(result);
+			pending.delete(result.packageName);
+			states.set(result.packageName, result.success ? "success" : "failed");
+		}
+		if (policy.failFast && batchResults.some((r) => !r.success)) {
+			cancelled.push(...pending);
+			if (isJsonReporter())
+				for (const packageName of pending)
+					emitEvent("task_blocked", { packageName, reason: "fail_fast_cancelled" });
+			await ProcessRunner.terminateAll();
+			break;
+		}
+	}
+	return { results, blocked, cancelled };
+}

--- a/src/core/selection.test.ts
+++ b/src/core/selection.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "bun:test";
+import { selectPackages } from "./selection.ts";
+import type { PackageInfo, WorkspaceInfo } from "./workspace.ts";
+
+const pkg = (name: string, dependencies: string[] = [], path = name): PackageInfo => ({
+	name,
+	path: `/repo/${path}`,
+	packageJson: { name },
+	dependencies,
+	devDependencies: [],
+	scripts: {},
+});
+const packages = [pkg("core"), pkg("ui", ["core"]), pkg("app", ["ui"], "apps/app"), pkg("docs")];
+const workspace = {
+	root: "/repo",
+	packages,
+	packageMap: new Map(packages.map((p) => [p.name, p])),
+	packageManager: {} as WorkspaceInfo["packageManager"],
+};
+
+describe("package selectors", () => {
+	it("expands dependencies and dependents", () => {
+		expect(selectPackages(workspace, ["app..."]).packages.map((p) => p.name)).toEqual([
+			"core",
+			"ui",
+			"app",
+		]);
+		expect(selectPackages(workspace, ["...core"]).packages.map((p) => p.name)).toEqual([
+			"core",
+			"ui",
+			"app",
+		]);
+	});
+	it("composes repeated and negative filters", () => {
+		expect(selectPackages(workspace, ["*", "!docs"]).packages.map((p) => p.name)).toEqual([
+			"core",
+			"ui",
+			"app",
+		]);
+	});
+	it("matches package paths", () => {
+		expect(selectPackages(workspace, ["./apps/*"]).packages.map((p) => p.name)).toEqual([
+			"app",
+		]);
+	});
+});

--- a/src/core/selection.ts
+++ b/src/core/selection.ts
@@ -1,0 +1,116 @@
+import { relative, sep } from "path";
+import type { PackageInfo, WorkspaceInfo } from "./workspace.ts";
+
+export interface PackageSelector {
+	raw: string;
+	exclude: boolean;
+	dependencies: boolean;
+	dependents: boolean;
+	pattern: string;
+}
+export interface SelectionReason {
+	packageName: string;
+	reasons: string[];
+}
+export interface SelectionResult {
+	packages: PackageInfo[];
+	reasons: SelectionReason[];
+}
+
+function allDeps(pkg: PackageInfo): string[] {
+	return [
+		...new Set([
+			...pkg.dependencies,
+			...pkg.devDependencies,
+			...(pkg.optionalDependencies || []),
+			...(pkg.peerDependencies || []),
+		]),
+	];
+}
+
+export function parseSelector(raw: string): PackageSelector {
+	if (!raw || raw === "!" || raw === "..." || raw === "!..." || raw.includes("......"))
+		throw new Error(`Malformed package selector: ${raw}`);
+	let value = raw;
+	const exclude = value.startsWith("!");
+	if (exclude) value = value.slice(1);
+	const dependents = value.startsWith("...");
+	const dependencies = value.endsWith("...");
+	if (dependents) value = value.slice(3);
+	if (dependencies) value = value.slice(0, -3);
+	if (!value) throw new Error(`Malformed package selector: ${raw}`);
+	return { raw, exclude, dependencies, dependents, pattern: value };
+}
+
+function globRegex(pattern: string): RegExp {
+	return new RegExp(
+		`^${pattern
+			.replace(/[.+^${}()|\\]/g, "\\$&")
+			.replace(/\*/g, ".*")
+			.replace(/\?/g, ".")}$`,
+	);
+}
+
+export function selectPackages(
+	workspace: WorkspaceInfo,
+	rawSelectors: string[] = [],
+): SelectionResult {
+	const selectors = rawSelectors.map(parseSelector);
+	const children = workspace.packages;
+	const candidates = workspace.rootPackage ? [...children, workspace.rootPackage] : children;
+	const byName = new Map(candidates.map((p) => [p.name, p]));
+	const root = workspace.rootPackage;
+	const dependents = new Map<string, string[]>();
+	for (const pkg of candidates)
+		for (const dep of allDeps(pkg))
+			dependents.set(dep, [...(dependents.get(dep) || []), pkg.name]);
+
+	const match = (selector: PackageSelector): Set<string> => {
+		const found = new Set<string>();
+		if (selector.pattern === "root" && root) found.add(root.name);
+		else if (selector.pattern.startsWith("./")) {
+			const pattern = selector.pattern.slice(2);
+			const regex = globRegex(pattern);
+			for (const pkg of children)
+				if (regex.test(relative(workspace.root, pkg.path).split(sep).join("/")))
+					found.add(pkg.name);
+		} else {
+			const regex = globRegex(selector.pattern);
+			for (const pkg of children) if (regex.test(pkg.name)) found.add(pkg.name);
+		}
+		const expand = (direction: "deps" | "dependents") => {
+			const queue = [...found];
+			while (queue.length) {
+				const name = queue.shift()!;
+				const next =
+					direction === "deps" ? allDeps(byName.get(name)!) : dependents.get(name) || [];
+				for (const item of next)
+					if (byName.has(item) && !found.has(item)) {
+						found.add(item);
+						queue.push(item);
+					}
+			}
+		};
+		if (selector.dependencies) expand("deps");
+		if (selector.dependents) expand("dependents");
+		return found;
+	};
+
+	let selected = new Set<string>();
+	const positive = selectors.filter((s) => !s.exclude);
+	if (selectors.length === 0 || positive.length === 0)
+		children.forEach((p) => selected.add(p.name));
+	for (const selector of positive) for (const name of match(selector)) selected.add(name);
+	for (const selector of selectors.filter((s) => s.exclude))
+		for (const name of match(selector)) selected.delete(name);
+	if (selectors.length && selected.size === 0)
+		throw new Error("No packages matched the supplied filters");
+	return {
+		packages: candidates.filter((p) => selected.has(p.name)),
+		reasons: [...selected].map((packageName) => ({ packageName, reasons: ["filter"] })),
+	};
+}
+
+export function getAllDependencies(pkg: PackageInfo): string[] {
+	return allDeps(pkg);
+}

--- a/src/core/workspace.test.ts
+++ b/src/core/workspace.test.ts
@@ -363,7 +363,7 @@ describe("WorkspaceParser", () => {
 	describe("error handling", () => {
 		it("should throw error when no workspace configuration found", () => {
 			expect(() => new WorkspaceParser(testDir)).toThrow(
-				"No package manager detected. Please ensure you have a lock file (bun.lockb, pnpm-lock.yaml, or package-lock.json) or workspace configuration in your project.",
+				"No package manager detected. Expected Bun, pnpm, npm, or a Yarn Berry project with an identifying lock/configuration file.",
 			);
 		});
 

--- a/src/core/workspace.ts
+++ b/src/core/workspace.ts
@@ -4,13 +4,27 @@ import fg from "fast-glob";
 import { PackageManagerDetector } from "../package-managers/index.ts";
 import type { PackageManager } from "../package-managers/index.ts";
 
+export type DependencyKind =
+	| "dependency"
+	| "devDependency"
+	| "optionalDependency"
+	| "peerDependency";
+export interface PackageDependency {
+	name: string;
+	range: string;
+	kind: DependencyKind;
+}
+
 export interface PackageInfo {
 	name: string;
 	path: string;
 	packageJson: Record<string, unknown>;
 	dependencies: string[];
 	devDependencies: string[];
+	optionalDependencies?: string[];
+	peerDependencies?: string[];
 	scripts: Record<string, string>;
+	isRoot?: boolean;
 }
 
 export interface WorkspaceInfo {
@@ -18,6 +32,7 @@ export interface WorkspaceInfo {
 	packages: PackageInfo[];
 	packageMap: Map<string, PackageInfo>;
 	packageManager: PackageManager;
+	rootPackage?: PackageInfo;
 }
 
 export class WorkspaceParser {
@@ -39,8 +54,13 @@ export class WorkspaceParser {
 		const packagePaths = await this.resolvePackagePaths(workspaceConfig.packages || []);
 		const packages = await Promise.all(packagePaths.map((path) => this.loadPackageInfo(path)));
 
+		const rootPackage = existsSync(join(this.workspaceRoot, "package.json"))
+			? await this.loadPackageInfo(this.workspaceRoot, true)
+			: undefined;
 		const packageMap = new Map<string, PackageInfo>();
 		packages.forEach((pkg) => {
+			if (packageMap.has(pkg.name))
+				throw new Error(`Duplicate workspace package name: ${pkg.name}`);
 			packageMap.set(pkg.name, pkg);
 		});
 
@@ -49,6 +69,7 @@ export class WorkspaceParser {
 			packages,
 			packageMap,
 			packageManager: this.packageManager,
+			rootPackage,
 		};
 	}
 
@@ -120,7 +141,12 @@ export class WorkspaceParser {
 			for (const path of paths) {
 				const packageJsonPath = join(this.workspaceRoot, path, "package.json");
 				if (existsSync(packageJsonPath)) {
-					packagePaths.push(resolve(this.workspaceRoot, path));
+					const resolvedPath = resolve(this.workspaceRoot, path);
+					if (!resolvedPath.startsWith(this.workspaceRoot + "/"))
+						throw new Error(
+							`Workspace package resolves outside the workspace root: ${path}`,
+						);
+					packagePaths.push(resolvedPath);
 				}
 			}
 		}
@@ -152,7 +178,7 @@ export class WorkspaceParser {
 	/**
 	 * Load package.json and extract relevant information
 	 */
-	private async loadPackageInfo(packagePath: string): Promise<PackageInfo> {
+	private async loadPackageInfo(packagePath: string, isRoot = false): Promise<PackageInfo> {
 		const packageJsonPath = join(packagePath, "package.json");
 
 		if (!existsSync(packageJsonPath)) {
@@ -168,10 +194,24 @@ export class WorkspaceParser {
 			throw new Error(`Package name not found in ${packageJsonPath}`);
 		}
 
-		const dependenciesObj = packageJson.dependencies as Record<string, string> | undefined;
-		const devDependenciesObj = packageJson.devDependencies as
-			| Record<string, string>
-			| undefined;
+		const dependencyField = (name: string): Record<string, string> => {
+			const value = packageJson[name];
+			if (value === undefined) return {};
+			if (
+				!value ||
+				typeof value !== "object" ||
+				Array.isArray(value) ||
+				Object.values(value as Record<string, unknown>).some(
+					(entry) => typeof entry !== "string",
+				)
+			)
+				throw new Error(`Invalid ${name} field in ${packageJsonPath}`);
+			return value as Record<string, string>;
+		};
+		const dependenciesObj = dependencyField("dependencies");
+		const devDependenciesObj = dependencyField("devDependencies");
+		const optionalDependenciesObj = dependencyField("optionalDependencies");
+		const peerDependenciesObj = dependencyField("peerDependencies");
 		const scriptsObj = packageJson.scripts as Record<string, string> | undefined;
 
 		const dependencies = Object.keys(dependenciesObj || {});
@@ -179,12 +219,15 @@ export class WorkspaceParser {
 		const scripts = scriptsObj || {};
 
 		return {
-			name: packageJson.name,
+			name: isRoot ? "__wsu_root__" : packageJson.name,
 			path: packagePath,
 			packageJson,
 			dependencies,
 			devDependencies,
+			optionalDependencies: Object.keys(optionalDependenciesObj || {}),
+			peerDependencies: Object.keys(peerDependenciesObj || {}),
 			scripts,
+			isRoot,
 		};
 	}
 

--- a/src/package-managers/detector.test.ts
+++ b/src/package-managers/detector.test.ts
@@ -5,6 +5,7 @@ import { PackageManagerDetector } from "./detector.ts";
 import { BunPackageManager } from "./bun.ts";
 import { PnpmPackageManager } from "./pnpm.ts";
 import { NpmPackageManager } from "./npm.ts";
+import { YarnPackageManager } from "./yarn.ts";
 
 describe("PackageManagerDetector", () => {
 	const testDir = join(process.cwd(), "test-temp");
@@ -135,7 +136,7 @@ describe("PackageManagerDetector", () => {
 
 		it("should throw error when no package manager is detected", () => {
 			expect(() => PackageManagerDetector.detect(testDir)).toThrow(
-				"No package manager detected. Please ensure you have a lock file (bun.lockb, pnpm-lock.yaml, or package-lock.json) or workspace configuration in your project.",
+				"No package manager detected. Expected Bun, pnpm, npm, or a Yarn Berry project with an identifying lock/configuration file.",
 			);
 		});
 
@@ -184,10 +185,11 @@ describe("PackageManagerDetector", () => {
 		it("should return all supported package managers", () => {
 			const managers = PackageManagerDetector.getSupportedPackageManagers();
 
-			expect(managers).toHaveLength(3);
+			expect(managers).toHaveLength(4);
 			expect(managers[0]).toBeInstanceOf(BunPackageManager);
 			expect(managers[1]).toBeInstanceOf(PnpmPackageManager);
-			expect(managers[2]).toBeInstanceOf(NpmPackageManager);
+			expect(managers[2]).toBeInstanceOf(YarnPackageManager);
+			expect(managers[3]).toBeInstanceOf(NpmPackageManager);
 		});
 	});
 

--- a/src/package-managers/detector.ts
+++ b/src/package-managers/detector.ts
@@ -4,11 +4,13 @@ import type { PackageManager, PackageManagerDetectionResult } from "./types.ts";
 import { BunPackageManager } from "./bun.ts";
 import { PnpmPackageManager } from "./pnpm.ts";
 import { NpmPackageManager } from "./npm.ts";
+import { YarnPackageManager } from "./yarn.ts";
 
 export class PackageManagerDetector {
 	private static readonly packageManagers = [
 		new BunPackageManager(),
 		new PnpmPackageManager(),
+		new YarnPackageManager(),
 		new NpmPackageManager(),
 	];
 
@@ -30,8 +32,18 @@ export class PackageManagerDetector {
 
 		const [result] = results;
 		if (!result) {
+			if (existsSync(join(workspaceRoot, "yarn.lock"))) {
+				throw new Error(
+					"Yarn Classic or ambiguous Yarn project detected. Add .yarnrc.yml or packageManager: yarn@2+ for Yarn Berry.",
+				);
+			}
 			throw new Error(
-				"No package manager detected. Please ensure you have a lock file (bun.lockb, pnpm-lock.yaml, or package-lock.json) or workspace configuration in your project.",
+				"No package manager detected. Expected Bun, pnpm, npm, or a Yarn Berry project with an identifying lock/configuration file.",
+			);
+		}
+		if (results[1] && result.confidence >= 100 && results[1].confidence === result.confidence) {
+			throw new Error(
+				`Ambiguous package manager detection: ${result.packageManager.name} and ${results[1].packageManager.name}`,
 			);
 		}
 
@@ -82,6 +94,9 @@ export class PackageManagerDetector {
 				break;
 			case "npm":
 				if (existsSync(join(workspaceRoot, ".npmrc"))) confidence += 30;
+				break;
+			case "yarn":
+				if (existsSync(join(workspaceRoot, ".yarnrc.yml"))) confidence += 80;
 				break;
 		}
 

--- a/src/package-managers/index.ts
+++ b/src/package-managers/index.ts
@@ -1,6 +1,7 @@
 export { BunPackageManager } from "./bun.ts";
 export { PnpmPackageManager } from "./pnpm.ts";
 export { NpmPackageManager } from "./npm.ts";
+export { YarnPackageManager } from "./yarn.ts";
 export { PackageManagerDetector } from "./detector.ts";
 export type {
 	PackageManager,

--- a/src/package-managers/yarn.test.ts
+++ b/src/package-managers/yarn.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { YarnPackageManager } from "./yarn.ts";
+
+const root = join(process.cwd(), "test-temp-yarn");
+describe("YarnPackageManager", () => {
+	afterEach(() => {
+		if (existsSync(root)) rmSync(root, { recursive: true, force: true });
+	});
+	it("detects and parses Yarn Berry workspaces", () => {
+		mkdirSync(root, { recursive: true });
+		writeFileSync(join(root, ".yarnrc.yml"), "nodeLinker: node-modules\n");
+		writeFileSync(
+			join(root, "package.json"),
+			JSON.stringify({ packageManager: "yarn@4.5.0", workspaces: ["packages/*"] }),
+		);
+		const yarn = new YarnPackageManager();
+		expect(yarn.isActive(root)).toBe(true);
+		expect(yarn.parseWorkspaceConfig(root)).toEqual({ packages: ["packages/*"] });
+		expect(yarn.getRunCommand("test")).toEqual({ command: "yarn", args: ["run", "test"] });
+	});
+});

--- a/src/package-managers/yarn.ts
+++ b/src/package-managers/yarn.ts
@@ -1,0 +1,32 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import type { PackageManager, WorkspaceConfig } from "./types.ts";
+
+export class YarnPackageManager implements PackageManager {
+	readonly name = "yarn";
+	isActive(root: string): boolean {
+		if (existsSync(join(root, ".yarnrc.yml"))) return true;
+		try {
+			const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+			const match =
+				typeof pkg.packageManager === "string" && pkg.packageManager.match(/^yarn@(\d+)/);
+			return Boolean(match && Number(match[1]) >= 2);
+		} catch {
+			return false;
+		}
+	}
+	getRunCommand(scriptName: string) {
+		return { command: "yarn", args: ["run", scriptName] };
+	}
+	parseWorkspaceConfig(root: string): WorkspaceConfig {
+		const pkg = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+		const workspaces = pkg.workspaces;
+		if (Array.isArray(workspaces)) return { packages: workspaces };
+		if (workspaces && Array.isArray(workspaces.packages))
+			return { packages: workspaces.packages };
+		throw new Error("No workspaces configuration found in package.json");
+	}
+	getLockFileName(): string {
+		return "yarn.lock";
+	}
+}

--- a/src/utils/command-options.ts
+++ b/src/utils/command-options.ts
@@ -1,0 +1,51 @@
+import type { PackageInfo, WorkspaceInfo } from "../core/workspace.ts";
+import { selectPackages } from "../core/selection.ts";
+import { findAffectedPackages } from "../core/affected.ts";
+
+export interface CommonCommandOptions {
+	filter?: string[] | string;
+	affected?: boolean;
+	since?: string;
+	dryRun?: boolean;
+	concurrency?: string;
+	retry?: string;
+	timeout?: string;
+	failFast?: boolean;
+	continueOnError?: boolean;
+}
+
+export function parsePositiveInteger(
+	value: string | undefined,
+	name: string,
+	fallback: number,
+	allowZero = false,
+): number {
+	if (value === undefined) return fallback;
+	const number = Number(value);
+	if (!Number.isInteger(number) || (allowZero ? number < 0 : number <= 0))
+		throw new Error(`${name} must be ${allowZero ? "a non-negative" : "a positive"} integer`);
+	return number;
+}
+
+export function parseDuration(value?: string): number | undefined {
+	if (!value) return undefined;
+	const match = value.match(/^(\d+)(ms|s|m)?$/);
+	if (!match || Number(match[1]) <= 0)
+		throw new Error("timeout must be a positive duration such as 500ms, 30s, or 5m");
+	return Number(match[1]) * (match[2] === "m" ? 60000 : match[2] === "s" ? 1000 : 1);
+}
+
+export function resolveTargets(
+	workspace: WorkspaceInfo,
+	options: CommonCommandOptions,
+): PackageInfo[] {
+	if (options.failFast && options.continueOnError)
+		throw new Error("--fail-fast and --continue-on-error are mutually exclusive");
+	const filters = typeof options.filter === "string" ? [options.filter] : options.filter || [];
+	let packages = selectPackages(workspace, filters).packages;
+	if (options.affected || options.since) {
+		const affected = findAffectedPackages(workspace, { since: options.since });
+		packages = packages.filter((pkg) => affected.has(pkg.name));
+	}
+	return packages;
+}

--- a/src/utils/package-utils.ts
+++ b/src/utils/package-utils.ts
@@ -24,7 +24,12 @@ export function buildDependencyGraph(packages: PackageInfo[]): DependencyGraph {
 	// Add dependency relationships
 	packages.forEach((pkg) => {
 		// Check both dependencies and devDependencies
-		const allDeps = [...pkg.dependencies, ...pkg.devDependencies];
+		const allDeps = [
+			...pkg.dependencies,
+			...pkg.devDependencies,
+			...(pkg.optionalDependencies || []),
+			...(pkg.peerDependencies || []),
+		];
 
 		allDeps.forEach((depName) => {
 			// Only add dependency if it's also a workspace package
@@ -107,6 +112,7 @@ export function prepareCommandExecution(
 			logOptions: {
 				prefix: pkg.name,
 				color: getPackageColor(pkg.name),
+				taskName: scriptName,
 			},
 			packageInfo: pkg,
 		};


### PR DESCRIPTION
## Summary

- add local artifact caching and deterministic restoration inferred from package metadata
- add relationship-aware package selectors, Git-based affected detection, and dependency-aware task scheduling
- add dry-run planning, dependency graph output, JSON Lines reporting, and configurable failure policies
- add Yarn Berry support, richer workspace dependency handling, and validation for ambiguous or unsafe workspaces
- update command documentation and cache guidance

## Why

workspace-utils previously orchestrated scripts and skipped unchanged builds, but it could not restore deleted build outputs, select packages by graph relationship or Git impact, or expose execution plans to CI. This expands those capabilities while preserving the zero-configuration model and existing command defaults.

## Developer impact

New CLI capabilities include:

- repeatable `--filter` selectors with dependency/dependent ellipses and exclusions
- `--affected` and `--since`
- `run --topological`
- `--dry-run`
- `--output json` for JSON Lines events
- `--fail-fast`, `--continue-on-error`, `--retry`, and `--timeout`
- `wsu graph --format text|json|dot`

Build artifacts are inferred from `files`, package entry points, `bin`, and `exports`. Packages without inferable artifacts continue building normally without artifact caching.

## Validation

- `bun test` — 224 passing
- `bun run format:check`
- `bun run lint`
- `bun run build`
- `bun run docs:build`
- manual JSON Lines parsing smoke test
- end-to-end artifact deletion/restoration test
