### PR TITLE
Install dependencies before building docs in deploy workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,9 @@ jobs:
             - name: Setup Pages
               id: pages
               uses: actions/configure-pages@v5
+            - name: Install dependencies
+              run: bun install --frozen-lockfile
+              working-directory: .
             - name: Build with docia
               run: bunx --bun docia build
             - name: Upload artifact


### PR DESCRIPTION
## Summary
The **Deploy Docs** workflow has been failing on main since the docia 0.0.15 bump (#14) with a bare `Bundle failed` during the "Bundling client assets" step.

Root cause: the workflow runs `bunx --bun docia build` straight after checkout without installing project dependencies. That worked on docia 0.0.10, but since 0.0.15 the client bundling step needs docia's dependencies (react, shiki, …) present in `node_modules`. The **Check** workflow passes on the same commits because it runs `bun install` before `bun run docs:build`.

## Fix
Add a `bun install --frozen-lockfile` step (at the repo root) before the build. Side benefit: with `node_modules` present, `bunx` uses the docia version pinned in `bun.lock` instead of the latest on npm, so future docia releases can't break deploys unexpectedly.

## Verification
In a clean worktree of main:
- `bunx --bun docia build` without install → fails to resolve docia
- `bun install --frozen-lockfile` then `GITHUB_PAGES=true bunx --bun docia build` → succeeds (13 pages, 32 emitted files), with no lockfile changes